### PR TITLE
#23: smaller Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+Dockerfile*
+.drone.yml
+.git
+README.md
+.gitignore
+.dockerignore

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -4,50 +4,18 @@ FROM tensorflow/tensorflow:1.14.0-py3-jupyter
 # ==== OUR STUFF FOLLOWS ====
 ENV last-update "2019-07-27 11:25"
 
-RUN apt-get install -y curl
-
-# Node
-RUN curl -sL https://deb.nodesource.com/setup_8.x |bash
-RUN apt-get update && apt-get install -y git nodejs
-RUN node -v
-
 WORKDIR /app
 ADD ./scripts /scripts
 ADD requirements.txt /app/requirements.txt
 ADD package.json /app/package.json
 ADD package-lock.json /app/package-lock.json
 
-# Data science stuff
-RUN apt-get install -y libsm6 libxrender-dev libxext6 unzip wget
-RUN pip install -r requirements.txt
-RUN jupyter serverextension enable --py jupyterlab_dotscience_backend --sys-prefix
-
-## install and activate the browser extension
-RUN npm install
-RUN cd node_modules/@dotscience/jupyterlab-plugin && jupyter labextension install .
-
-# for branch builds, replace the above with this and specify the branch in 'git
-# checkout' below
-#RUN git clone https://github.com/dotmesh-io/jupyterlab-plugin && \
-#    cd jupyterlab-plugin && \
-#    git checkout frontend-ng-498-reverse-commits-hide-initial && \
-#    cd jupyterlab_dotscience && \
-#    npm install -g typescript && \
-#    npm install -g . && \
-#    tsc && \
-#    jupyter labextension install . || (cat /tmp/jupyterlab-debug-*.log ; false)
-
-# Enable a more liberal Content-Security-Policy so that we can display Jupyter
-# in an iframe.
-RUN bash /scripts/update-content-security-policy.sh
-
-# Autosave every second to avoid having to save after a run for Dotscience to
-# trigger a run.
-RUN mkdir -p /usr/local/share/jupyter/lab/settings && echo '{"@jupyterlab/docmanager-extension:plugin":{"autosaveInterval": 1}}' > /usr/local/share/jupyter/lab/settings/overrides.json
-
-# Clean up files which otherwise get copied into the workspace dot, at the
-# expense of a few hundred meg.
-RUN cd /root && rm -rf .cache .conda .config .npm work .yarn
+# Install code we want, in a script so we can delete unneeded files and not have
+# them end up in the Docker image. Because it's one script the Docker builds
+# will be fairly slow, since they can't rely on caching. If the build slowness
+# ever becomes an issue we can switch to multi-stage builds, but it's probably
+# not worth it at this point since the code doesn't change that often.
+RUN /bin/bash /scripts/install-dotscience-changes.sh
 
 ## override the entrypoint to allow root
 CMD /bin/bash /scripts/start-jupyter.sh

--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -18,4 +18,4 @@ ADD package-lock.json /app/package-lock.json
 RUN /bin/bash /scripts/install-dotscience-changes.sh
 
 ## override the entrypoint to allow root
-CMD /bin/bash /scripts/start-jupyter.sh
+CMD ["/bin/bash", "/scripts/start-jupyter.sh"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -4,51 +4,18 @@ FROM tensorflow/tensorflow:1.14.0-gpu-py3-jupyter
 # ==== OUR STUFF FOLLOWS ====
 ENV last-update "2019-07-27 11:25"
 
-RUN apt-get install -y curl
-
-# Node
-RUN curl -sL https://deb.nodesource.com/setup_8.x |bash
-RUN apt-get update && apt-get install -y git nodejs
-RUN node -v
-
-# Data science stuff
-RUN apt-get install -y libsm6 libxrender-dev libxext6 unzip wget
-
 WORKDIR /app
 ADD ./scripts /scripts
 ADD requirements.txt /app/requirements.txt
 ADD package.json /app/package.json
 ADD package-lock.json /app/package-lock.json
 
-RUN pip install -r requirements.txt
-RUN jupyter serverextension enable --py jupyterlab_dotscience_backend --sys-prefix
-
-## install and activate the browser extension
-RUN npm install
-RUN cd node_modules/@dotscience/jupyterlab-plugin && jupyter labextension install .
-
-# for branch builds, replace the above with this and specify the branch in 'git
-# checkout' below
-#RUN git clone https://github.com/dotmesh-io/jupyterlab-plugin && \
-#    cd jupyterlab-plugin && \
-#    git checkout frontend-ng-498-reverse-commits-hide-initial && \
-#    cd jupyterlab_dotscience && \
-#    npm install -g typescript && \
-#    npm install -g . && \
-#    tsc && \
-#    jupyter labextension install . || (cat /tmp/jupyterlab-debug-*.log ; false)
-
-# Enable a more liberal Content-Security-Policy so that we can display Jupyter
-# in an iframe.
-RUN bash /scripts/update-content-security-policy.sh
-
-# Autosave every second to avoid having to save after a run for Dotscience to
-# trigger a run.
-RUN mkdir -p /usr/local/share/jupyter/lab/settings && echo '{"@jupyterlab/docmanager-extension:plugin":{"autosaveInterval": 1}}' > /usr/local/share/jupyter/lab/settings/overrides.json
-
-# Clean up files which otherwise get copied into the workspace dot, at the
-# expense of a few hundred meg.
-RUN cd /root && rm -rf .cache .conda .config .npm work .yarn
+# Install code we want, in a script so we can delete unneeded files and not have
+# them end up in the Docker image. Because it's one script the Docker builds
+# will be fairly slow, since they can't rely on caching. If the build slowness
+# ever becomes an issue we can switch to multi-stage builds, but it's probably
+# not worth it at this point since the code doesn't change that often.
+RUN /bin/bash /scripts/install-dotscience-changes.sh
 
 ## override the entrypoint to allow root
 CMD /bin/bash /scripts/start-jupyter.sh

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -18,4 +18,4 @@ ADD package-lock.json /app/package-lock.json
 RUN /bin/bash /scripts/install-dotscience-changes.sh
 
 ## override the entrypoint to allow root
-CMD /bin/bash /scripts/start-jupyter.sh
+CMD ["/bin/bash", "/scripts/start-jupyter.sh"]

--- a/scripts/install-dotscience-changes.sh
+++ b/scripts/install-dotscience-changes.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+apt-get install -y --no-install-recommends curl
+
+# Node
+curl -sL https://deb.nodesource.com/setup_8.x |bash
+apt-get update && apt-get install -y --no-install-recommends git nodejs
+node -v
+
+# Data science stuff
+apt-get install -y --no-install-recommends libsm6 libxrender-dev libxext6 unzip wget
+pip install -r requirements.txt
+jupyter serverextension enable --py jupyterlab_dotscience_backend --sys-prefix
+
+## install and activate the browser extension
+npm install
+cd node_modules/@dotscience/jupyterlab-plugin && jupyter labextension install .
+
+# for branch builds, replace the above with this and specify the branch in 'git
+# checkout' below
+#git clone https://github.com/dotmesh-io/jupyterlab-plugin && \
+#    cd jupyterlab-plugin && \
+#    git checkout frontend-ng-498-reverse-commits-hide-initial && \
+#    cd jupyterlab_dotscience && \
+#    npm install -g typescript && \
+#    npm install -g . && \
+#    tsc && \
+#    jupyter labextension install . || (cat /tmp/jupyterlab-debug-*.log ; false)
+
+# Enable a more liberal Content-Security-Policy so that we can display Jupyter
+# in an iframe.
+bash /scripts/update-content-security-policy.sh
+
+# Autosave every second to avoid having to save after a run for Dotscience to
+# trigger a run.
+mkdir -p /usr/local/share/jupyter/lab/settings && echo '{"@jupyterlab/docmanager-extension:plugin":{"autosaveInterval": 1}}' > /usr/local/share/jupyter/lab/settings/overrides.json
+
+# Clean up files which otherwise get copied into the workspace dot, at the
+# expense of a few hundred meg.
+cd /root && rm -rf .cache .conda .config .npm work .yarn
+rm -rf /app/node_modules
+
+# Uninstall apt packages and caches we no longer need:
+apt-get remove -y libxrender-dev git nodejs curl wget unzip
+apt autoremove -y
+apt-get clean
+rm -rf /var/lib/apt/lists/*

--- a/scripts/start-jupyter.sh
+++ b/scripts/start-jupyter.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -xe
+set -xeuo pipefail
 
 # make sure we use the -w flag passed to docker run as where to load the notebooks
 # from - this will be the same place as the workspace dot is mounted
@@ -9,4 +9,4 @@ export SHELL=bash
 # expects git clone https://github.com/dotmesh-io/jupyterlab-plugin /plugin/jupyterlab-plugin
 # in dev mode - we have mounted the jupyterlab-plugin repo to /plugin/jupyterlab-plugin
 #source activate base
-jupyter lab --ip 0.0.0.0 --port 8888 --allow-root --notebook-dir "$NOTEBOOK_DIR"
+exec jupyter lab --ip 0.0.0.0 --port 8888 --allow-root --notebook-dir "$NOTEBOOK_DIR"


### PR DESCRIPTION
Fixes #23.

The compressed image (what you download with `docker pull`) goes from 987MB to 777MB. The uncompressed on-disk image should have proportional savings.