### PR TITLE
Update dotscience to 0.6.6 and cut duplicate requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dotscience==0.5.0
+dotscience==0.6.6
 jupyterlab==1.0.9
 jupyterlab-dotscience-backend==0.2.17
 opencv-python==4.1.0.25
@@ -6,4 +6,3 @@ scikit-image==0.15.0
 seaborn==0.9.0
 sklearn==0.0
 scikit-learn==0.21.3
-git+git://github.com/dotmesh-io/python-sdk@bb1ace821d13b496e01efe4d748aa76e648d841b#egg=datadots-api


### PR DESCRIPTION
Think since we already depend on datadots api in dotscience we shouldn't need it here.