### PR TITLE
minify js builds of jupyterlab-tensorflow

### DIFF
--- a/scripts/install-browser-extension.sh
+++ b/scripts/install-browser-extension.sh
@@ -9,4 +9,4 @@ cd /plugin/jupyterlab-plugin/jupyterlab_dotscience
 npm install
 npm run build
 
-jupyter labextension install .
+jupyter labextension install . --dev-build=False


### PR DESCRIPTION
Per https://github.com/jupyterlab/jupyterlab/issues/5661, try setting --dev-build=False on jupyter labextension install to use a prod build and therefore minify the JS

**NOTE** I have not yet been able to actually test the resulting build to see if it (a) works and (b) has smaller JS

was seeing 28MB or so in our prod vs 2.8MB on https://jupyter.org/try